### PR TITLE
[experiment] Don't merge: extracting triggerLinters into distinct pieces

### DIFF
--- a/lib/editor-linter.coffee
+++ b/lib/editor-linter.coffee
@@ -53,34 +53,63 @@ class EditorLinter
 
     scopes = @editor.scopeDescriptorForBufferPosition(@editor.getCursorBufferPosition()).scopes
     scopes.push '*' # To allow global linters
-    @triggerLinters(true, wasTriggeredOnChange, scopes).then( =>
-      return Promise.all(@triggerLinters(false, wasTriggeredOnChange, scopes))
-    ).then =>
+    messages = []
+
+    # Since I'm using filter I need a functional version of the helper.
+    shouldTriggerLinter = (linter) ->
+      Helpers.shouldTriggerLinter(linter, wasTriggeredOnChange, scopes)
+
+    toRun = @linter.getLinterArray().filter(shouldTriggerLinter)
+    modifyingLinters = toRun.filter((linter) -> linter.modifiesBuffer)
+    linters = toRun.filter((linter) -> !linter.modifiesBuffer)
+
+    # modifying linters must run in sequence
+    modMessages = @runSequentialLinters(modifyingLinters)
+    messages = @runParalellLinters(linters)
+
+    Promise.all([modMessages, messages]).then(@storeMessages).then =>
       @lock(wasTriggeredOnChange, false)
 
-  # This method returns an array of promises to be used in lint
-  triggerLinters: (bufferModifying, wasTriggeredOnChange, scopes) ->
-    ToReturn = if bufferModifying then Promise.resolve() else []
-    @linter.getLinters().forEach (linter) =>
-      return if linter.modifiesBuffer isnt bufferModifying
-      return unless Helpers.shouldTriggerLinter(linter, wasTriggeredOnChange, scopes)
-      currentLinter = =>
-        return new Promise((resolve) =>
-          resolve(linter.lint(@editor, Helpers))
-        ).then((results) =>
-          if linter.scope is 'project'
-            @linter.setMessages(linter, results)
-          else
-            # Trigger event instead of updating on purpose, because
-            # we want to make MessageRegistry the central message repo
-            @emitter.emit('should-update', {linter, results})
-        ).catch (error) ->
-          atom.notifications.addError error.message, {detail: error.stack, dismissable: true}
-      if bufferModifying
-        ToReturn.then -> currentLinter()
+  storeMessages: ([modMessageMap, fileMessageMap]) =>
+    store = (results, linter) =>
+      if linter.scope is 'project'
+        @linter.setMessages(linter, results)
       else
-        ToReturn.push(currentLinter())
-    ToReturn
+        # Trigger event instead of updating on purpose, because
+        # we want to make MessageRegistry the central message repo
+        @emitter.emit('should-update', {linter, results})
+
+    modMessageMap.forEach(store)
+    fileMessageMap.forEach(store)
+
+  # Consumes an array of linters and returns a `Map` of litners to messages
+  runSequentialLinters: (linters) ->
+    return linters.reduce(((promise, linter) =>
+      promise.then((messageMap) =>
+        @runLinter(linter).then((messages) =>
+          messageMap.set(linter, messages)
+          return messageMap
+        )
+      )
+    ), Promise.resolve(new Map) )
+
+  # Consumes an array of linters and returns a `Map` of litners to messages
+  runParalellLinters: (linters) ->
+    fileMessageMap = new Map()
+    messages = Promise.all(linters.map((linter) =>
+      @runLinter(linter).then((messages) ->
+        fileMessageMap.set(linter, messages)
+      )
+    )).then(-> fileMessageMap)
+
+  runLinter: (linter) ->
+    return new Promise((resolve) =>
+      resolve(linter.lint(@editor, Helpers))
+    ).catch (error) ->
+      atom.notifications.addError error.message, {detail: error.stack, dismissable: true}
+      # fake a return value since the error has been handled by showing it to
+      # the user
+      return []
 
   # This method sets or gets the lock status of given type
   lock: (wasTriggeredOnChange, value) ->

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -19,7 +19,7 @@ class Linter
     @subscriptions = new CompositeDisposable
     @emitter = new Emitter
     @editorLinters = new Map
-    @linters = new Set # Values are pushed here from Main::consumeLinter
+    @linters = []
 
     @messages = new Messages @
     @views = new LinterViews @
@@ -44,8 +44,7 @@ class Linter
   addLinter: (linter) ->
     try
       if(Helpers.validateLinter(linter))
-        delete @linterArray
-        @linters.add(linter)
+        @linters.push(linter)
     catch err
       atom.notifications.addError("Invalid Linter: #{err.message}", {
         detail: err.stack,
@@ -54,23 +53,14 @@ class Linter
 
   deleteLinter: (linter) ->
     return unless @hasLinter(linter)
-    delete @linterArray
-    @linters.delete(linter)
+    @linters = @linters.filter((l) -> l isnt linter)
     @deleteMessages(linter)
 
   hasLinter: (linter) ->
-    @linters.has(linter)
+    @linters.filter((l) -> l is linter).length > 0
 
   getLinters: ->
     @linters
-
-  getLinterArray: ->
-    unless @linterArray?
-      @linterArray = []
-      @getLinters().forEach (l) => @linterArray.push(l)
-
-    @linterArray
-
 
   setMessages: (linter, messages) ->
     @messages.set(linter, messages)

--- a/lib/linter-plus.coffee
+++ b/lib/linter-plus.coffee
@@ -44,6 +44,7 @@ class Linter
   addLinter: (linter) ->
     try
       if(Helpers.validateLinter(linter))
+        delete @linterArray
         @linters.add(linter)
     catch err
       atom.notifications.addError("Invalid Linter: #{err.message}", {
@@ -53,6 +54,7 @@ class Linter
 
   deleteLinter: (linter) ->
     return unless @hasLinter(linter)
+    delete @linterArray
     @linters.delete(linter)
     @deleteMessages(linter)
 
@@ -61,6 +63,14 @@ class Linter
 
   getLinters: ->
     @linters
+
+  getLinterArray: ->
+    unless @linterArray?
+      @linterArray = []
+      @getLinters().forEach (l) => @linterArray.push(l)
+
+    @linterArray
+
 
   setMessages: (linter, messages) ->
     @messages.set(linter, messages)


### PR DESCRIPTION
`triggerLinters` was actually doing several things and seemed hard to follow. I consider this an early draft of what it might look like to break it into pieces that each do one thing.

Now there is a distinct stage for gathering all of the data, and then a stage to store that data. I'm out of time for today, but each of these functions can be tested easier than the whole `triggerLinters`