### PR TITLE
Update coffeelint.json With atom/atom's Version

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,43 +1,37 @@
-
 {
-  "arrow_spacing": {
-    "name": "arrow_spacing",
-    "level": "error"
-  },
-  "ensure_comprehensions": {
-    "name": "ensure_comprehensions",
-    "level": "error"
-  },
   "max_line_length": {
-    "name": "max_line_length",
-    "value": 120,
-    "level": "error",
-    "limitComments": true
-  },
-  "indentation": {
-    "name": "indentation",
-    "value": 2,
-    "level": "error"
+    "level": "ignore"
   },
   "no_empty_param_list": {
-    "name": "no_empty_param_list",
     "level": "error"
   },
-  "cyclomatic_complexity": {
-    "name": "cyclomatic_complexity",
-    "value": 22,
+  "arrow_spacing": {
     "level": "error"
   },
-  "no_unnecessary_fat_arrows": {
-    "name": "no_unnecessary_fat_arrows",
+  "no_interpolation_in_single_quotes": {
     "level": "error"
   },
-  "space_operators": {
-    "name": "space_operators",
+  "no_debugger": {
+    "level": "error"
+  },
+  "prefer_english_operator": {
+    "level": "error"
+  },
+  "colon_assignment_spacing": {
+    "spacing": {
+      "left": 0,
+      "right": 1
+    },
+    "level": "error"
+  },
+  "braces_spacing": {
+    "spaces": 0,
     "level": "error"
   },
   "spacing_after_comma": {
-    "name": "spacing_after_comma",
+    "level": "error"
+  },
+  "no_stand_alone_at": {
     "level": "error"
   }
 }


### PR DESCRIPTION
This PR simply replaces the contents of coffeelint.json with the contents from https://github.com/atom/atom/blob/92e495db6880c3c26c5afd2953550ff27043edcd/coffeelint.json. This is done to match the core team's style guide.