### PR TITLE
:fire: Comment 'alt' keybinding as a workaround to #648

### DIFF
--- a/keymaps/linter.cson
+++ b/keymaps/linter.cson
@@ -1,3 +1,2 @@
 'atom-text-editor:not(.mini)':
-#  'alt': 'linter:set-bubble-transparent'
   'alt->': 'linter:next-error'

--- a/keymaps/linter.cson
+++ b/keymaps/linter.cson
@@ -1,3 +1,3 @@
 'atom-text-editor:not(.mini)':
-  'alt': 'linter:set-bubble-transparent'
+#  'alt': 'linter:set-bubble-transparent'
   'alt->': 'linter:next-error'


### PR DESCRIPTION
It has passed more than 20 days by now of #648 report and It shouldn't be acceptable that the plugin break atom keybinding in such way for too long, I'm sending a PR commenting the keybinding on the plugin as a temporary workaround until we get a proper fix.