### PR TITLE
Use JSON as message key

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -6,8 +6,6 @@ child_process = require('child_process')
 Helpers = module.exports =
   error: (e) ->
     atom.notifications.addError(e.message, {detail: e.stack, dismissible: true})
-  messageKey: (message) ->
-    return JSON.stringify(message)
   shouldTriggerLinter: (linter, bufferModifying, onChange, scopes) ->
     # Trigger lint-on-Fly linters on both events but on-save linters only on save
     # Because we want to trigger onFly linters on save when the

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -7,9 +7,7 @@ Helpers = module.exports =
   error: (e) ->
     atom.notifications.addError(e.message, {detail: e.stack, dismissible: true})
   messageKey: (message) ->
-    text = message.text or message.html
-    toReturn = message.type + '-' + message.filePath + '-' + (message.range?.serialize?()) + '-' + text
-    toReturn.toLowerCase()
+    return JSON.stringify(message)
   shouldTriggerLinter: (linter, bufferModifying, onChange, scopes) ->
     # Trigger lint-on-Fly linters on both events but on-save linters only on save
     # Because we want to trigger onFly linters on save when the

--- a/lib/validate.coffee
+++ b/lib/validate.coffee
@@ -23,7 +23,7 @@ module.exports = Validate =
       unless result.html or result.text
         throw new Error "Missing html/text field on Linter Response"
       result.range = Range.fromObject result.range if result.range?
+      result.key = JSON.stringify(result)
       result.class = result.type.toLowerCase().replace(' ', '-')
-      result.key = helpers.messageKey(result)
       Validate.messages(result.trace) if result.trace
     return undefined

--- a/spec/helpers-spec.coffee
+++ b/spec/helpers-spec.coffee
@@ -8,14 +8,6 @@ describe 'helpers', ->
       helpers.error(new Error())
       expect(atom.notifications.getNotifications().length).toBe(1)
 
-  describe '::messageKey', ->
-    it 'works', ->
-      key = helpers.messageKey({type: 'error', text: ''})
-      expect(key.length).toBeGreaterThan(0)
-    it 'generates a lowercase key', ->
-      key = helpers.messageKey({type: 'error', text: ''})
-      expect(key).toBe(key.toLowerCase())
-
   describe '::shouldTriggerLinter', ->
     normalLinter =
       grammarScopes: ['*']


### PR DESCRIPTION
Because it's simple and dependable
In the future PRs I'll be implementing efficient markers

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atom-community/linter/785)
<!-- Reviewable:end -->
