### PR TITLE
Allow stringish errors

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -5,7 +5,7 @@ child_process = require('child_process')
 
 Helpers = module.exports =
   error: (e) ->
-    atom.notifications.addError(e.message, {detail: e.stack, dismissable: true})
+    atom.notifications.addError(e.toString(), {detail: e.stack or '', dismissable: true})
   shouldTriggerLinter: (linter, bufferModifying, onChange, scopes) ->
     # Trigger lint-on-Fly linters on both events but on-save linters only on save
     # Because we want to trigger onFly linters on save when the


### PR DESCRIPTION
Atom-Linter module at the moment throws stringish errors, I am gonna fix this in that module as well. But thought we should be handling this scenario