### PR TITLE
Reverted ability to select status-bar side

### DIFF
--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -109,10 +109,12 @@ class LinterViews
       ) if @underlineIssues
 
   attachBottom: (statusBar) ->
-    statusIconPosition = atom.config.get('linter.statusIconPosition')
-    @bottomBar = statusBar["add#{statusIconPosition}Tile"]
-      item: @bottomContainer,
-      priority: if statusIconPosition == 'Left' then -100 else 100
+    @subscriptions.add atom.config.observe('linter.statusIconPosition', (statusIconPosition) =>
+      @bottomBar?.destroy()
+      @bottomBar = statusBar["add#{statusIconPosition}Tile"]
+        item: @bottomContainer,
+        priority: if statusIconPosition == 'Left' then -100 else 100
+    )
 
   removeMarkers: (messages = @messages) ->
     messages.forEach((message) =>

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -109,9 +109,10 @@ class LinterViews
       ) if @underlineIssues
 
   attachBottom: (statusBar) ->
-    @bottomBar = statusBar.addLeftTile
+    statusIconPosition = atom.config.get('linter.statusIconPosition')
+    @bottomBar = statusBar["add#{statusIconPosition}Tile"]
       item: @bottomContainer,
-      priority: -100
+      priority: if statusIconPosition == 'Left' then -100 else 100
 
   removeMarkers: (messages = @messages) ->
     messages.forEach((message) =>

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -43,6 +43,12 @@ module.exports =
       type: 'string'
       enum: ['File', 'Line', 'Project']
       default: 'Project'
+    statusIconPosition:
+      title: 'Position of Status Icon on Bottom Bar'
+      description: 'Requires a reload/restart to update'
+      enum: ['Left', 'Right']
+      type: 'string'
+      default: 'Left'
 
   activate: (@state) ->
     LinterPlus = require('./linter.coffee')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -45,7 +45,6 @@ module.exports =
       default: 'Project'
     statusIconPosition:
       title: 'Position of Status Icon on Bottom Bar'
-      description: 'Requires a reload/restart to update'
       enum: ['Left', 'Right']
       type: 'string'
       default: 'Left'

--- a/spec/ui/bottom-panel-mount-spec.coffee
+++ b/spec/ui/bottom-panel-mount-spec.coffee
@@ -1,0 +1,22 @@
+describe 'BottomPanelMount', ->
+  [statusBar, statusBarService, workspaceElement] = []
+  beforeEach ->
+    workspaceElement = atom.views.getView(atom.workspace)
+    waitsForPromise ->
+      atom.packages.activatePackage('status-bar').then (pack) ->
+        statusBar = workspaceElement.querySelector('status-bar')
+        statusBarService = pack.mainModule.provideStatusBar()
+    waitsForPromise ->
+      atom.packages.activatePackage('linter').then (pack) ->
+        atom.packages.getActivePackage('linter').mainModule.consumeStatusBar(statusBar)
+    waitsForPromise ->
+      atom.workspace.open()
+
+  it 'can mount to left status-bar', ->
+    tile = statusBar.getLeftTiles()[0]
+    expect(tile.item.localName).toBe('linter-bottom-container')
+
+  it 'can mount to right status-bar', ->
+    atom.config.set('linter.statusIconPosition', 'Right')
+    tile = statusBar.getRightTiles()[0]
+    expect(tile.item.localName).toBe('linter-bottom-container')


### PR DESCRIPTION
Just reverted the `statusIconPosition` setting from e36281e3d4e8cfdae29c71ac790ebdfb1ae58030 and updated the attach function since there is only one container now. Additionally, the dynamic priority assures the tile will snap to the corresponding side.

Fixes #720 and resolves the regression in #575, #576, #630

Thanks for your time!