### PR TITLE
Fix extra padding in panel when there's no messages

### DIFF
--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -52,9 +52,16 @@ linter-panel {
   display: block;
   overflow-y: auto;
   max-height: 150px;
-  padding: @spacing;
   &[hidden]{
     display: none;
+  }
+  padding-left: @spacing;
+  padding-right: @spacing;
+  linter-message:first-child {
+    padding-top: @spacing;
+  }
+  linter-message:last-child {
+    padding-bottom: @spacing;
   }
 }
 
@@ -87,7 +94,7 @@ linter-panel {
   a {
     color: @linter-inline-link;
     &:last-of-type {
-      padding-right: @spacing*1.5; // a bit extra space for visual pleasing
+      padding-right: @spacing * 1.5; // a bit extra space for visual pleasing
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/atom-community/linter/issues/876

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atom-community/linter/879)
<!-- Reviewable:end -->
