### PR TITLE
Fixed gutter corruption on Atom 1.0.13 - And looks better

### DIFF
--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -138,7 +138,6 @@ atom-text-editor::shadow .linter-highlight .icon-right{
   visibility: visible;
   &::before{
     content: @primitive-dot;
-    font-size: 1.1em;
   }
 }
 // Styling Error Types


### PR DESCRIPTION
Under recent versions of Atom setting margins or font sizes in the butter will cause alignment issues
This fixes that ... The dot was kinda large anyway, so I think it looks better now