### PR TITLE
Handle markers in editor-linter

### DIFF
--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -13,6 +13,9 @@ export default class EditorLinter {
     this.markers = new WeakMap()
     this.subscriptions = new CompositeDisposable
 
+    this.subscriptions.add(atom.config.observe('linter.underlineIssues', underlineIssues =>
+      this.underlineIssues = underlineIssues
+    ))
     this.subscriptions.add(this.editor.onDidDestroy(() =>
       this.emitter.emit('did-destroy')
     ))
@@ -34,35 +37,26 @@ export default class EditorLinter {
     })
   }
 
-  updateMarkers({added, removed}) {
-    // TODO: Handle the path validation in notifier
-    const editorPath = this.editor.getPath()
-    const underlineIssues = atom.config.get('linter.underlineIssues')
-
-    removed.forEach(message => {
-      if (!this.markers.has(message)) return
-
+  addMessage(message) {
+    const marker = this.editor.markBufferRange(message.range, {invalidate: 'inside'})
+    this.markers.set(message, marker)
+    this.editor.decorateMarker(marker, {
+      type: 'line-number',
+      class: `linter-highlight ${message.class}`
+    })
+    if (this.underlineIssues) {
+      this.editor.decorateMarker(marker, {
+        type: 'highlight',
+        class: `linter-highlight ${message.class}`
+      })
+    }
+  }
+  removeMessage(message) {
+    if (this.markers.has(message)) {
       const marker = this.markers.get(message)
       marker.destroy()
       this.markers.delete(marker)
-    })
-
-    added.forEach(message => {
-      if (!message.range || !message.filePath || message.filePath !== editorPath) return
-
-      const marker = this.editor.markBufferRange(message.range, {invalidate: 'inside'})
-      this.markers.set(message, marker)
-      this.editor.decorateMarker(marker, {
-        type: 'line-number',
-        class: `linter-highlight ${message.class}`
-      })
-      if (underlineIssues) {
-        this.editor.decorateMarker(marker, {
-          type: 'highlight',
-          class: `linter-highlight ${message.class}`
-        })
-      }
-    })
+    }
   }
 
   lint(onChange = false) {

--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -10,6 +10,7 @@ export default class EditorLinter {
 
     this.editor = editor
     this.emitter = new Emitter()
+    this.markers = new WeakMap()
     this.subscriptions = new CompositeDisposable
 
     this.subscriptions.add(this.editor.onDidDestroy(() =>
@@ -30,6 +31,32 @@ export default class EditorLinter {
       this.subscriptions.add(this.editor.onDidStopChanging(() =>
         this.emitter.emit('should-lint', true)
       ))
+    })
+  }
+
+  updateMarkers({added, removed}) {
+    // TODO: Handle the path validation in notifier
+    const editorPath = this.editor.getPath()
+
+    removed.forEach(message => {
+      if (!this.markers.has(message)) return
+
+      const marker = this.markers.get(message)
+      marker.destroy()
+      this.markers.delete(marker)
+    })
+
+    console.log(added)
+    added.forEach(message => {
+      if (!message.range || !message.filePath || message.filePath !== editorPath) return
+
+      const marker = this.editor.markBufferRange(message.range, {invalidate: 'inside'})
+      this.markers.set(message, marker)
+      this.editor.decorateMarker(marker, {
+        type: 'line-highlight',
+        class: `linter-highlight ${message.class}`
+      })
+      // TODO: `highlight` marker
     })
   }
 

--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -51,6 +51,7 @@ export default class EditorLinter {
       })
     }
   }
+
   removeMessage(message) {
     if (this.markers.has(message)) {
       const marker = this.markers.get(message)

--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -37,6 +37,7 @@ export default class EditorLinter {
   updateMarkers({added, removed}) {
     // TODO: Handle the path validation in notifier
     const editorPath = this.editor.getPath()
+    const underlineIssues = atom.config.get('linter.underlineIssues')
 
     removed.forEach(message => {
       if (!this.markers.has(message)) return
@@ -55,7 +56,12 @@ export default class EditorLinter {
         type: 'line-number',
         class: `linter-highlight ${message.class}`
       })
-      // TODO: `highlight` marker
+      if (underlineIssues) {
+        this.editor.decorateMarker(marker, {
+          type: 'highlight',
+          class: `linter-highlight ${message.class}`
+        })
+      }
     })
   }
 

--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -17,7 +17,7 @@ export default class EditorLinter {
       this.underlineIssues = underlineIssues
     ))
     this.subscriptions.add(this.editor.onDidDestroy(() =>
-      this.emitter.emit('did-destroy')
+      this.destroy()
     ))
     this.subscriptions.add(this.editor.onDidSave(() =>
       this.emitter.emit('should-lint', false)

--- a/lib/editor-linter.js
+++ b/lib/editor-linter.js
@@ -46,14 +46,13 @@ export default class EditorLinter {
       this.markers.delete(marker)
     })
 
-    console.log(added)
     added.forEach(message => {
       if (!message.range || !message.filePath || message.filePath !== editorPath) return
 
       const marker = this.editor.markBufferRange(message.range, {invalidate: 'inside'})
       this.markers.set(message, marker)
       this.editor.decorateMarker(marker, {
-        type: 'line-highlight',
+        type: 'line-number',
         class: `linter-highlight ${message.class}`
       })
       // TODO: `highlight` marker

--- a/lib/editor-registry.coffee
+++ b/lib/editor-registry.coffee
@@ -20,7 +20,6 @@ class EditorRegistry
     @editorLinters.set(textEditor, editorLinter)
     editorLinter.onDidDestroy =>
       @editorLinters.delete(textEditor)
-      editorLinter.dispose()
     @emitter.emit('observe', editorLinter)
     return editorLinter
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -93,9 +93,9 @@ class LinterViews
     @bottomContainer.setCount(@count)
 
   renderPanelMarkers: ({added, removed}) ->
-    activeEditor = @linter.getActiveEditorLinter()
-    return unless activeEditor
-    activeEditor.updateMarkers({added, removed})
+    @linter.eachEditorLinter((editorLinter) =>
+        editorLinter.updateMarkers({added, removed})
+    )
 
   attachBottom: (statusBar) ->
     @subscriptions.add atom.config.observe('linter.statusIconPosition', (statusIconPosition) =>

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -22,7 +22,6 @@ class LinterViews
     )
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem =>
       @classifyMessages(@messages)
-      @renderPanelMarkers({added: @messages, removed: @messages})
       @renderBubble()
       @renderCount()
       @panel.refresh(@state.scope)

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -10,7 +10,6 @@ class LinterViews
     @state = @linter.state
     @subscriptions = new CompositeDisposable
     @messages = []
-    @markers = new WeakMap()
     @panel = new BottomPanel(@state.scope)
     @bottomContainer = new BottomContainer().prepare(@linter.state)
     @bottomBar = null
@@ -98,18 +97,7 @@ class LinterViews
     @bottomContainer.setCount(@count)
 
   renderPanelMarkers: ({added, removed}) ->
-    @removeMarkers(removed)
-    activeEditor = atom.workspace.getActiveTextEditor()
-    return unless activeEditor
-    added.forEach (message) =>
-      return unless message.currentFile
-      @markers.set(message, marker = activeEditor.markBufferRange message.range, {invalidate: 'inside'})
-      activeEditor.decorateMarker(
-        marker, type: 'line-number', class: "linter-highlight #{message.class}"
-      )
-      activeEditor.decorateMarker(
-        marker, type: 'highlight', class: "linter-highlight #{message.class}"
-      ) if @underlineIssues
+
 
   attachBottom: (statusBar) ->
     @subscriptions.add atom.config.observe('linter.statusIconPosition', (statusIconPosition) =>
@@ -122,20 +110,11 @@ class LinterViews
       @bottomContainer.setVisibility(displayLinterInfo)
     )
 
-  removeMarkers: (messages = @messages) ->
-    messages.forEach((message) =>
-      return unless @markers.has(message)
-      marker = @markers.get(message)
-      marker.destroy()
-      @markers.delete(message)
-    )
-
   removeBubble: ->
     @bubble?.destroy()
     @bubble = null
 
   dispose: ->
-    @removeMarkers()
     @removeBubble()
     @subscriptions.dispose()
     @bottomBar?.destroy()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -97,7 +97,9 @@ class LinterViews
     @bottomContainer.setCount(@count)
 
   renderPanelMarkers: ({added, removed}) ->
-
+    activeEditor = @linter.getActiveEditorLinter()
+    return unless activeEditor
+    activeEditor.updateMarkers({added, removed})
 
   attachBottom: (statusBar) ->
     @subscriptions.add atom.config.observe('linter.statusIconPosition', (statusIconPosition) =>

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -42,12 +42,12 @@ class LinterViews
     removed.forEach (message) =>
       return unless message.filePath and message.range
       unless editorLinter = @linter.getEditorLinterByPath(message.filePath)
-        then return
+        return
       editorLinter.removeMessage(message)
     added.forEach (message) =>
       return unless message.filePath and message.range
       unless editorLinter = @linter.getEditorLinterByPath(message.filePath)
-      then return
+        return
       editorLinter.addMessage(message)
 
   renderLineMessages: (render = false) ->

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -50,6 +50,12 @@ class LinterViews
         return
       editorLinter.addMessage(message)
 
+  notifyEditor: (editorLinter) ->
+    editorPath = editorLinter.editor.getPath()
+    @messages.forEach (message) ->
+      return unless message.filePath and message.range and message.filePath is editorPath
+      editorLinter.addMessage(message)
+
   renderLineMessages: (render = false) ->
     @classifyMessagesByLine(@messages)
     if render

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -110,6 +110,9 @@ class LinterViews
     @bubble = null
 
   dispose: ->
+    @linter.eachEditorLinter((editorLinter) =>
+      editorLinter.updateMarkers({added: [], removed: @messages})
+    )
     @removeBubble()
     @subscriptions.dispose()
     @bottomBar?.destroy()

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -34,9 +34,11 @@ class LinterViews
   render: ({added, removed, messages}) ->
     @messages = @classifyMessages(messages)
     @panel.setMessages({added, removed})
-    @renderPanelMarkers({added, removed})
     @renderBubble()
     @renderCount()
+    @linter.eachEditorLinter((editorLinter) =>
+      editorLinter.updateMarkers({added, removed})
+    )
 
   renderLineMessages: (render = false) ->
     @classifyMessagesByLine(@messages)
@@ -91,11 +93,6 @@ class LinterViews
 
   renderCount: ->
     @bottomContainer.setCount(@count)
-
-  renderPanelMarkers: ({added, removed}) ->
-    @linter.eachEditorLinter((editorLinter) =>
-        editorLinter.updateMarkers({added, removed})
-    )
 
   attachBottom: (statusBar) ->
     @subscriptions.add atom.config.observe('linter.statusIconPosition', (statusIconPosition) =>

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -17,9 +17,6 @@ class LinterViews
     @count = File: 0, Line: 0, Project: 0
 
     @subscriptions.add @panel
-    @subscriptions.add atom.config.observe('linter.underlineIssues', (underlineIssues) =>
-      @underlineIssues = underlineIssues
-    )
     @subscriptions.add atom.config.observe('linter.showErrorInline', (showBubble) =>
       @showBubble = showBubble
     )

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -41,13 +41,11 @@ class LinterViews
   notifyEditors: ({added, removed}) ->
     removed.forEach (message) =>
       return unless message.filePath and message.range
-      unless editorLinter = @linter.getEditorLinterByPath(message.filePath)
-        return
+      return unless editorLinter = @linter.getEditorLinterByPath(message.filePath)
       editorLinter.removeMessage(message)
     added.forEach (message) =>
       return unless message.filePath and message.range
-      unless editorLinter = @linter.getEditorLinterByPath(message.filePath)
-        return
+      return unless editorLinter = @linter.getEditorLinterByPath(message.filePath)
       editorLinter.addMessage(message)
 
   notifyEditor: (editorLinter) ->

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -107,7 +107,7 @@ class Linter
       @linters.lint({onChange, editorLinter})
     editorLinter.onDidDestroy =>
       @messages.deleteEditorMessages(editor)
-    editorLinter.updateMarkers({removed: [], added: @views.messages})
+    @views.notifyEditor(editorLinter)
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -88,6 +88,9 @@ class Linter
   getEditorLinter: (editor) ->
     @editors.ofTextEditor(editor)
 
+  getEditorLinterByPath: (path) ->
+    @editors.ofPath(path)
+
   eachEditorLinter: (callback) ->
     @editors.forEach(callback)
 

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -104,6 +104,7 @@ class Linter
       @linters.lint({onChange, editorLinter})
     editorLinter.onDidDestroy =>
       @messages.deleteEditorMessages(editor)
+    editorLinter.updateMarkers({removed: [], added: @views.messages})
 
   deactivate: ->
     @subscriptions.dispose()

--- a/spec/common.coffee
+++ b/spec/common.coffee
@@ -4,8 +4,8 @@ EditorLinter = require('../lib/editor-linter')
 module.exports =
   getLinter: ->
     return {grammarScopes: ['*'], lintOnFly: false, modifiesBuffer: false, scope: 'project', lint: -> }
-  getMessage: (type, filePath) ->
-    return {type, text: "Some Message", filePath}
+  getMessage: (type, filePath, range) ->
+    return {type, text: "Some Message", filePath, range}
   getLinterRegistry: ->
     linterRegistry = new LinterRegistry
     editorLinter = new EditorLinter(atom.workspace.getActiveTextEditor())

--- a/spec/editor-linter-spec.coffee
+++ b/spec/editor-linter-spec.coffee
@@ -1,11 +1,12 @@
 describe 'editor-linter', ->
+  {getMessage} = require('./common')
   EditorLinter = require('../lib/editor-linter')
   editorLinter = null
   textEditor = null
   beforeEach ->
     waitsForPromise ->
       atom.workspace.destroyActivePaneItem()
-      atom.workspace.open('/tmp/test.txt').then ->
+      atom.workspace.open(__dirname + '/fixtures/file.txt').then ->
         editorLinter?.dispose()
         textEditor = atom.workspace.getActiveTextEditor()
         editorLinter = new EditorLinter(textEditor)
@@ -21,6 +22,15 @@ describe 'editor-linter', ->
       expect ->
         new EditorLinter(55)
       .toThrow()
+
+  describe '::{add, remove}Message', ->
+    it 'adds/removes decorations from the editor', ->
+      countDecorations = textEditor.getDecorations().length
+      message = getMessage('Hey!', __dirname + '/fixtures/file.txt', [[0, 1], [0, 2]])
+      editorLinter.addMessage(message)
+      expect(textEditor.getDecorations().length).toBe(countDecorations + 1)
+      editorLinter.removeMessage(message)
+      expect(textEditor.getDecorations().length).toBe(countDecorations)
 
   describe '::onShouldLint', ->
     it 'ignores instant save requests', ->

--- a/spec/editor-registry-spec.coffee
+++ b/spec/editor-registry-spec.coffee
@@ -4,7 +4,7 @@ describe 'editor-registry', ->
   beforeEach ->
     waitsForPromise ->
       atom.workspace.destroyActivePaneItem()
-      atom.workspace.open('test.txt')
+      atom.workspace.open(__dirname + '/fixtures/file.txt')
     editorRegistry?.dispose()
     editorRegistry = new EditorRegistry
 
@@ -40,8 +40,22 @@ describe 'editor-registry', ->
       expect(editorRegistry.ofTextEditor("asd")).toBeUndefined()
     it 'returns editorLinter when valid key is provided', ->
       activeEditor = atom.workspace.getActiveTextEditor()
+      expect(editorRegistry.ofTextEditor(activeEditor)).toBeUndefined()
       editorRegistry.create(activeEditor)
       expect(editorRegistry.ofTextEditor(activeEditor)).toBeDefined()
+
+  describe '::ofPath', ->
+    it 'returns undefined when invalid key is provided', ->
+      expect(editorRegistry.ofPath(null)).toBeUndefined()
+      expect(editorRegistry.ofPath(1)).toBeUndefined()
+      expect(editorRegistry.ofPath(5)).toBeUndefined()
+      expect(editorRegistry.ofPath("asd")).toBeUndefined()
+    it 'returns editorLinter when valid key is provided', ->
+      activeEditor = atom.workspace.getActiveTextEditor()
+      editorPath = activeEditor.getPath()
+      expect(editorRegistry.ofPath(editorPath)).toBeUndefined()
+      editorRegistry.create(activeEditor)
+      expect(editorRegistry.ofPath(editorPath)).toBeDefined()
 
   describe '::observe', ->
     it 'calls with the current editorLinters', ->


### PR DESCRIPTION
Features:
  - Markers will be available in different editors at the same time
  - Everytime a tab is switched, we remove all the markers from previous tab and re-add all the markers in new tab, keeping them in both would mean no unnecessary operations.
  - more that I can't think of right now

This does come at a speed regression. I'll be fixed it afterwards.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atom-community/linter/899)
<!-- Reviewable:end -->
