### PR TITLE
Fix linter message styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
 * Linter now supports decorating multiple panes at the same time. Decorations are no longer removed and re-added on tab changed, only added to the new tab. Which could improve the tab switch performance with large errors.
+* Multiline messages render correctly by allowing overflow and using flexbox to enable single line output of the location.
 
 ## 1.6.0
 

--- a/lib/ui/message-element.js
+++ b/lib/ui/message-element.js
@@ -37,7 +37,7 @@ export class Message extends HTMLElement {
     const pathEl = document.createElement('span')
     let displayFile = message.filePath
 
-    el.className = 'linter-message-item'
+    el.className = 'linter-message-item linter-message-link'
 
     for (let path of atom.project.getPaths())
       if (displayFile.indexOf(path) === 0) {

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -5,19 +5,21 @@
 
 linter-message {
   display: flex;
-  align-items: flex-end;
-  flex-wrap: wrap;
+  align-items: flex-start;
   font-size: @font-size;
   line-height: 1.2;
-  & > .badge {
-    align-self: flex-start;
-  }
 }
 
 .linter-message-item {
   margin: @spacing;
-  height: 1.8em;
-  white-space: nowrap;
+}
+
+.linter-highlight {
+  flex: 0 0 auto;
+}
+
+.linter-message-link {
+  flex: 1 0 auto;
 }
 
 linter-multiline-message {


### PR DESCRIPTION
Fixes #893. Related to #892 and #859.

![image](https://cloud.githubusercontent.com/assets/1088987/10089450/e4bd73ea-62d8-11e5-8545-39a9adb1016f.png)

On a related note, I did not find any output of the `multiline` class so this is purely the CSS fix.