### PR TITLE
Disable path in bubble and improve link/text flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Linter now supports decorating multiple panes at the same time. Decorations are no longer removed and re-added on tab changed, only added to the new tab. Which could improve the tab switch performance with large errors.
 * Multiline messages render correctly by allowing overflow and using flexbox to enable single line output of the location.
+* Remove location from bubble information.
 
 ## 1.6.0
 

--- a/lib/linter-views.coffee
+++ b/lib/linter-views.coffee
@@ -98,7 +98,7 @@ class LinterViews
   renderBubbleContent: (message) ->
     bubble = document.createElement 'div'
     bubble.id = 'linter-inline'
-    bubble.appendChild Message.fromMessage(message)
+    bubble.appendChild Message.fromMessage(message, false)
     if message.trace then message.trace.forEach (trace) ->
       element = Message.fromMessage(trace)
       bubble.appendChild element

--- a/lib/ui/message-element.js
+++ b/lib/ui/message-element.js
@@ -3,8 +3,9 @@
 const NewLine = /\r?\n/
 
 export class Message extends HTMLElement {
-  initialize(message) {
+  initialize(message, includeLink = true) {
     this.message = message
+    this.includeLink = includeLink
     return this
   }
   updateVisibility(scope) {
@@ -16,8 +17,8 @@ export class Message extends HTMLElement {
 
     if (this.children.length && this.message.filePath)
       if (scope === 'Project')
-        this.children[this.children.length - 1].children[0].removeAttribute('hidden')
-      else this.children[this.children.length - 1].children[0].setAttribute('hidden', true)
+        this.querySelector('.linter-message-link span').removeAttribute('hidden')
+      else this.querySelector('.linter-message-link span').setAttribute('hidden', true)
 
     if (status)
       this.removeAttribute('hidden')
@@ -26,18 +27,14 @@ export class Message extends HTMLElement {
   }
   attachedCallback() {
     this.appendChild(Message.getRibbon(this.message))
-    this.appendChild(Message.getMessage(this.message))
-
-    if (this.message.filePath) {
-      this.appendChild(Message.getLink(this.message))
-    }
+    this.appendChild(Message.getMessage(this.message, this.includeLink))
   }
   static getLink(message) {
     const el = document.createElement('a')
     const pathEl = document.createElement('span')
     let displayFile = message.filePath
 
-    el.className = 'linter-message-item linter-message-link'
+    el.className = 'linter-message-link'
 
     for (let path of atom.project.getPaths())
       if (displayFile.indexOf(path) === 0) {
@@ -59,11 +56,21 @@ export class Message extends HTMLElement {
     })
     return el
   }
-  static getMessage(message) {
+  static getMessage(message, includeLink) {
     const el = document.createElement('span')
+    const messageEl = document.createElement('span')
+
     el.className = 'linter-message-item'
+
+    // Render link inside message content for float and auto flow text around.
+    if (includeLink && message.filePath) {
+      el.appendChild(Message.getLink(message))
+    }
+
+    el.appendChild(messageEl)
+
     if (message.html && typeof message.html !== 'string') {
-      el.appendChild(message.html.cloneNode(true))
+      messageEl.appendChild(message.html.cloneNode(true))
     } else if (
       message.multiline ||
       (message.html && message.html.match(NewLine)) ||
@@ -72,11 +79,12 @@ export class Message extends HTMLElement {
       return Message.getMultiLineMessage(message.html || message.text)
     } else {
       if (message.html) {
-        el.innerHTML = message.html
+        messageEl.innerHTML = message.html
       } else if (message.text) {
-        el.textContent = message.text
+        messageEl.textContent = message.text
       }
     }
+
     return el
   }
   static getMultiLineMessage(message) {
@@ -95,8 +103,8 @@ export class Message extends HTMLElement {
     el.textContent = message.type
     return el
   }
-  static fromMessage(message) {
-    return new MessageElement().initialize(message)
+  static fromMessage(message, includeLink) {
+    return new MessageElement().initialize(message, includeLink)
   }
 }
 

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -19,7 +19,8 @@ linter-message {
 }
 
 .linter-message-link {
-  flex: 1 0 auto;
+  float: right;
+  margin: 0 0 @spacing @spacing;
 }
 
 linter-multiline-message {


### PR DESCRIPTION
Here's an alternative keeping the text inline with the flow (meh):

![image](https://cloud.githubusercontent.com/assets/1088987/10090020/1f586428-62df-11e5-926a-257230ea6735.png)

Here's the current PR (same behaviour as before, but text will continue flowing below):

![image](https://cloud.githubusercontent.com/assets/1088987/10090152/b6c2474c-62e0-11e5-9ac8-5d7a92572f09.png)

And before (with bubble link):

![image](https://cloud.githubusercontent.com/assets/1088987/10090186/3e428b96-62e1-11e5-8b6c-9bbf499d9df6.png)
