### PR TITLE
use info as a style key, as well as trace

### DIFF
--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -180,7 +180,7 @@ atom-text-editor::shadow .linter-highlight, .linter-highlight{
       border-bottom: 1px dashed @background-color-warning;
     }
   }
-  &.trace {
+  &.trace, &.info {
     &:not(.line-number){
       background-color: @background-color-info;
       color: white;


### PR DESCRIPTION
Our plugin generates errors, warnings, and info level analysis issues. We'd like to be able to call them that in the UI; currently we use `Error`, `Warning`, and `Trace` in order to get css styling in the editor for info level events. This PR adds `info` as a synonym for `trace`.

<img width="287" alt="screen shot 2015-10-01 at 11 32 53 pm" src="https://cloud.githubusercontent.com/assets/1269969/10241057/91866c34-6898-11e5-83ce-c24c24477f9e.png">
