### PR TITLE
remove css top offset

### DIFF
--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -118,7 +118,6 @@ linter-bottom-tab {
   cursor: pointer;
   vertical-align: middle;
   position: relative;
-  top: -2px;
   &:first-of-type {
     border-top-left-radius: @component-border-radius;
     border-bottom-left-radius: @component-border-radius;


### PR DESCRIPTION
Remove a css `top:` offset. This seemed to be causing the linter status line contribution to be slightly off-center. I'm not sure if this is intentional or an artifact of some refactoring -

before:
<img width="143" alt="screen shot 2015-10-01 at 11 54 14 pm" src="https://cloud.githubusercontent.com/assets/1269969/10241151/d421d654-6899-11e5-81b4-fe6506d2974a.png">

<img width="130" alt="screen shot 2015-10-02 at 12 01 19 am" src="https://cloud.githubusercontent.com/assets/1269969/10241152/d4222604-6899-11e5-91ce-abc2e3b2a9af.png">

after:
<img width="142" alt="screen shot 2015-10-01 at 11 54 24 pm" src="https://cloud.githubusercontent.com/assets/1269969/10241154/df4c5086-6899-11e5-9678-056eec649e3f.png">
