### PR TITLE
made the text in the bottom panel selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Enable clicking on multiline messages to view next lines
 * Add default styles for `Info` type
 * Aligned bottom panel buttons
+* Made the text in the bottom panel selectable
 
 ## 1.7.2
 

--- a/lib/ui/bottom-panel.js
+++ b/lib/ui/bottom-panel.js
@@ -7,6 +7,7 @@ export class BottomPanel {
   constructor(scope) {
     this.subscriptions = new CompositeDisposable
     this.element = document.createElement('linter-panel') // TODO(steelbrain): Make this a `div`
+    this.element.tabIndex = "-1"
     this.panel = atom.workspace.addBottomPanel({item: this.element, visible: false, priority: 500})
     this.visibility = false
     this.scope = scope


### PR DESCRIPTION
Fix https://github.com/atom-community/linter/issues/909 - made the text in the bottom panel selectable.