### PR TITLE
Improve error panel sizing behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Upcoming
+
+* Allow panel resize to persist
+* Add option to always have the panel to fill the minimum space
+* Fix issue where external scope errors would cause panel to continue displaying
+
 ## 1.8.0
 
 * Improve rendering of multiline messages to align with recent single line changes

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -51,6 +51,18 @@ module.exports =
       type: 'boolean'
       default: true
       order: 4
+    errorPanelHeight:
+      title: 'Error Panel Height'
+      description: 'The error panel height in pixels'
+      type: 'number'
+      default: 150
+      order: 4
+    alwaysTakeMinimumSpace:
+      title: 'Always Take Minimum Space'
+      description: 'Resize the error panel smaller than the height where possible'
+      type: 'boolean'
+      default: true
+      order: 4
 
     displayLinterInfo:
       title: 'Display Linter Info in Status Bar'

--- a/lib/ui/bottom-panel.js
+++ b/lib/ui/bottom-panel.js
@@ -8,54 +8,88 @@ export class BottomPanel {
   constructor(scope) {
     this.subscriptions = new CompositeDisposable
     this.element = document.createElement('linter-panel') // TODO(steelbrain): Make this a `div`
-    this.element.tabIndex = "-1"
+    this.element.tabIndex = '-1'
+    this.messagesElement = document.createElement('div')
     this.panel = atom.workspace.addBottomPanel({item: this.element, visible: false, priority: 500})
     this.visibility = false
+    this.visibleMessages = 0
+    this.alwaysTakeMinimumSpace = atom.config.get('linter.alwaysTakeMinimumSpace')
+    this.errorPanelHeight = atom.config.get('linter.errorPanelHeight')
+    this.configVisibility = atom.config.get('linter.showErrorPanel')
     this.scope = scope
     this.messages = new Map()
 
-    this.subscriptions.add(atom.config.observe('linter.showErrorPanel', value => {
-      this.configVisibility = value
-      this.setVisibility(true)
-    }))
-    this.subscriptions.add(atom.workspace.observeActivePaneItem(paneItem => {
-      this.paneVisibility = paneItem === atom.workspace.getActiveTextEditor()
-      this.setVisibility(true)
+    // Keep messages contained to measure height.
+    this.element.appendChild(this.messagesElement)
+
+    this.subscriptions.add(atom.config.onDidChange('linter.alwaysTakeMinimumSpace', ({newValue, oldValue}) => {
+      this.alwaysTakeMinimumSpace = newValue
+      this.updateHeight()
     }))
 
-    Interact(this.element).resizable({edges: { top: true }})
-      .on('resizemove', function (event) {
-        var target = event.target;
-        if (event.rect.height < 25) {
-          if (event.rect.height < 1) {
-            target.style.width = target.style.height = null
-          } else return // No-Op
-        } else {
-          target.style.width  = event.rect.width + 'px'
-          target.style.height = event.rect.height + 'px'
-        }
+    this.subscriptions.add(atom.config.onDidChange('linter.errorPanelHeight', ({newValue, oldValue}) => {
+      this.errorPanelHeight = newValue
+      this.updateHeight()
+    }))
+
+    this.subscriptions.add(atom.config.onDidChange('linter.showErrorPanel', ({newValue, oldValue}) => {
+      this.configVisibility = newValue
+      this.updateVisibility()
+    }))
+
+    this.subscriptions.add(atom.workspace.observeActivePaneItem(paneItem => {
+      this.paneVisibility = paneItem === atom.workspace.getActiveTextEditor()
+      this.updateVisibility()
+    }))
+
+    Interact(this.element).resizable({edges: {top: true}})
+      .on('resizemove', event => {
+        event.target.style.height = `${event.rect.height}px`
+      })
+      .on('resizeend', event => {
+        atom.config.set('linter.errorPanelHeight', event.target.clientHeight)
       })
   }
   refresh(scope) {
     this.scope = scope
+    this.visibleMessages = 0
+
     for (let message of this.messages) {
-      message[1].updateVisibility(scope)
+      if (message[1].updateVisibility(scope).status) this.visibleMessages++
     }
+
+    this.updateVisibility()
   }
   setMessages({added, removed}) {
     if (removed.length)
       this.removeMessages(removed)
+
     for (let message of added) {
       const messageElement = Message.fromMessage(message)
-      this.element.appendChild(messageElement)
+      this.messagesElement.appendChild(messageElement)
       messageElement.updateVisibility(this.scope)
+      if (messageElement.status) this.visibleMessages++
       this.messages.set(message, messageElement)
     }
+
+    this.updateVisibility()
+  }
+  updateHeight() {
+    let height = this.errorPanelHeight
+
+    if (this.alwaysTakeMinimumSpace) {
+      // Add `1px` for the top border.
+      height = Math.min(this.messagesElement.clientHeight + 1, height)
+    }
+
+    this.element.style.height = `${height}px`
   }
   removeMessages(removed) {
     for (let message of removed) {
       if (this.messages.has(message)) {
-        this.element.removeChild(this.messages.get(message))
+        const messageElement = this.messages.get(message)
+        if (messageElement.status) this.visibleMessages--
+        this.messagesElement.removeChild(messageElement)
         this.messages.delete(message)
       }
     }
@@ -63,10 +97,12 @@ export class BottomPanel {
   getVisibility() {
     return this.visibility
   }
-  setVisibility(value) {
-    this.visibility = value && this.configVisibility && this.paneVisibility
+  updateVisibility() {
+    this.visibility = this.configVisibility && this.paneVisibility && this.visibleMessages > 0
+
     if (this.visibility) {
       this.panel.show()
+      this.updateHeight()
     } else {
       this.panel.hide()
     }

--- a/lib/ui/message-element.js
+++ b/lib/ui/message-element.js
@@ -6,6 +6,7 @@ export class Message extends HTMLElement {
   initialize(message, includeLink = true) {
     this.message = message
     this.includeLink = includeLink
+    this.status = false
     return this
   }
   updateVisibility(scope) {
@@ -26,9 +27,13 @@ export class Message extends HTMLElement {
       }
     }
 
+    this.status = status
+
     if (status) {
       this.removeAttribute('hidden')
     } else this.setAttribute('hidden', true)
+
+    return this
   }
   attachedCallback() {
     if (atom.config.get('linter.showProviderName') && this.message.linter) {

--- a/spec/commands-spec.coffee
+++ b/spec/commands-spec.coffee
@@ -6,9 +6,17 @@ describe 'Commands', ->
       atom.packages.activatePackage('linter').then ->
         linter = atom.packages.getActivePackage('linter').mainModule.instance
 
+  getMessage = (type, filePath) ->
+    return {type, text: 'Some Message', filePath}
+
   describe 'linter:togglePanel', ->
     it 'toggles the panel visibility', ->
+      # Set up visibility.
+      linter.views.panel.scope = 'Project'
+      linter.views.panel.setMessages({added: [getMessage('Error')], removed: []})
+
       visibility = linter.views.panel.getVisibility()
+      expect(visibility).toBe(true)
       linter.commands.togglePanel()
       expect(linter.views.panel.getVisibility()).toBe(not visibility)
       linter.commands.togglePanel()

--- a/spec/linter-behavior-spec.coffee
+++ b/spec/linter-behavior-spec.coffee
@@ -27,14 +27,18 @@ describe 'Linter Behavior', ->
       expect(linterState.scope).toBe('Project')
 
     it 'toggles panel visibility on click', ->
+      # Set up errors.
+      linter.views.panel.setMessages({added: [getMessage('Error')], removed: []})
+
+      trigger(bottomContainer.getTab('Project'), 'click')
       expect(linter.views.panel.getVisibility()).toBe(true)
-      trigger(bottomContainer.getTab('File'), 'click')
+      trigger(bottomContainer.getTab('Project'), 'click')
       expect(linter.views.panel.getVisibility()).toBe(false)
-      trigger(bottomContainer.getTab('File'), 'click')
-      expect(linter.views.panel.getVisibility()).toBe(true)
 
     it 're-enables panel when another tab is clicked', ->
-      expect(linter.views.panel.getVisibility()).toBe(true)
+      # Set up errors.
+      linter.views.panel.setMessages({added: [getMessage('Error')], removed: []})
+
       trigger(bottomContainer.getTab('File'), 'click')
       expect(linter.views.panel.getVisibility()).toBe(false)
       trigger(bottomContainer.getTab('Project'), 'click')
@@ -49,9 +53,11 @@ describe 'Linter Behavior', ->
       waitsForPromise ->
         atom.workspace.open('file.txt').then ->
           expect(bottomContainer.getTab('File').count).toBe(1)
+          expect(linter.views.panel.getVisibility()).toBe(true)
           atom.workspace.open('/tmp/non-existing-file')
         .then ->
           expect(bottomContainer.getTab('File').count).toBe(0)
+          expect(linter.views.panel.getVisibility()).toBe(false)
 
   describe 'Markers', ->
     it 'automatically marks files when they are opened if they have any markers', ->

--- a/spec/ui/bottom-panel-spec.coffee
+++ b/spec/ui/bottom-panel-spec.coffee
@@ -12,10 +12,14 @@ describe 'BottomPanel', ->
   getMessage = (type, filePath) ->
     return {type, text: 'Some Message', filePath}
 
-  it 'remains visible when theres no active pane', ->
-    expect(linter.views.panel.getVisibility()).toBe(true)
+  it 'is not visible when there are no errors', ->
+    expect(linter.views.panel.getVisibility()).toBe(false)
 
   it 'hides on config change', ->
+    # Set up visibility.
+    linter.views.panel.scope = 'Project'
+    linter.views.panel.setMessages({added: [getMessage('Error')], removed: []})
+
     expect(linter.views.panel.getVisibility()).toBe(true)
     atom.config.set('linter.showErrorPanel', false)
     expect(linter.views.panel.getVisibility()).toBe(false)
@@ -26,10 +30,10 @@ describe 'BottomPanel', ->
     it 'works as expected', ->
       messages = [getMessage('Error'), getMessage('Warning')]
       bottomPanel.setMessages({added: messages, removed: []})
-      expect(bottomPanel.element.childNodes.length).toBe(2)
+      expect(bottomPanel.element.childNodes[0].childNodes.length).toBe(2)
       bottomPanel.setMessages({added: [], removed: messages})
-      expect(bottomPanel.element.childNodes.length).toBe(0)
+      expect(bottomPanel.element.childNodes[0].childNodes.length).toBe(0)
       bottomPanel.setMessages({added: messages, removed: []})
-      expect(bottomPanel.element.childNodes.length).toBe(2)
+      expect(bottomPanel.element.childNodes[0].childNodes.length).toBe(2)
       bottomPanel.removeMessages(messages)
-      expect(bottomPanel.element.childNodes.length).toBe(0)
+      expect(bottomPanel.element.childNodes[0].childNodes.length).toBe(0)

--- a/styles/linter-plus.less
+++ b/styles/linter-plus.less
@@ -59,17 +59,10 @@ linter-multiline-message {
 linter-panel {
   display: block;
   overflow-y: auto;
-  max-height: 150px;
-  &[hidden]{
-    display: none;
-  }
-  padding-left: @spacing;
-  padding-right: @spacing;
-  linter-message:first-child {
-    padding-top: @spacing;
-  }
-  linter-message:last-child {
-    padding-bottom: @spacing;
+  min-height: 2em;
+
+  .linter-messages {
+    padding: @spacing;
   }
 }
 


### PR DESCRIPTION
Adds two options for controlling panel size - `errorPanelHeight` and `alwaysTakeMinimumSpace`. The error panel height can be manually configured, or automatically updated by using the drag feature  (results in persistence of height). The minimum space option is a toggle which causes the height of the panel to equal `min(height option, messages height)` (vs `height option`). This patch also closes an issue where the linter panel would stay open with no messages visible.

Closes #928

**Empty Linter Panel Issue:**

![image](https://cloud.githubusercontent.com/assets/1088987/10270111/23ef8ef6-6a9d-11e5-8210-ce1d5cb3c36d.png)

Edit: Had to modify tests to set-up visibility before checking (not visible by default when there's no error messages anymore).