### PR TITLE
Sort messages in bottom panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Major speed improvements
 * Make ctrl-c work on bottom panel
 * Fix certain scenarios where inline bubbles would be placed incorrectly (Bubbles no longer follow the cursor, they re-use markers from underlines)
+* Implement sorted messages (comes at a performance penality, can be turned off in configuration)
 
 ## 1.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Major speed improvements
 * Make ctrl-c work on bottom panel
 * Fix certain scenarios where inline bubbles would be placed incorrectly (Bubbles no longer follow the cursor, they re-use markers from underlines)
-* Implement sorted messages (comes at a performance penality, can be turned off in configuration)
+* Implement sorted messages (comes at a performance penalty, can be turned off in configuration)
 
 ## 1.8.1
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -17,6 +17,11 @@ module.exports =
       items:
         type: 'string'
       order: 2
+    sortMessages:
+      description: 'This comes at a performance penalty'
+      type: 'boolean'
+      default: true
+      order: 2
 
     showErrorInline:
       title: 'Show Inline Tooltips'

--- a/lib/ui/bottom-panel.js
+++ b/lib/ui/bottom-panel.js
@@ -18,6 +18,7 @@ export default class BottomPanel {
     this.errorPanelHeight = atom.config.get('linter.errorPanelHeight')
     this.configVisibility = atom.config.get('linter.showErrorPanel')
     this.scope = scope
+    this.sortedMessages = []
     this.messages = new Map()
 
     // Keep messages contained to measure height.
@@ -36,6 +37,10 @@ export default class BottomPanel {
     this.subscriptions.add(atom.config.onDidChange('linter.showErrorPanel', ({newValue}) => {
       this.configVisibility = newValue
       this.updateVisibility()
+    }))
+
+    this.subscriptions.add(atom.config.observe('linter.sortMessages', sortMessages => {
+      this.sortMessages = sortMessages
     }))
 
     this.subscriptions.add(atom.workspace.observeActivePaneItem(paneItem => {
@@ -74,13 +79,33 @@ export default class BottomPanel {
     if (removed.length)
       this.removeMessages(removed)
 
-    for (let message of added) {
-      const messageElement = Message.fromMessage(message)
-      this.messagesElement.appendChild(messageElement)
-      this.messages.set(message, messageElement)
-      if (messageElement.updateVisibility(this.scope).status) {
-        this.visibleMessages++
-      }
+    if (added.length) {
+      added.forEach((message) => {
+        const messageElement = Message.fromMessage(message)
+        this.messages.set(message, messageElement)
+        if (messageElement.updateVisibility(this.scope).status) {
+          this.visibleMessages++
+        }
+        if (this.sortMessages && message.range) {
+          let inserted = false
+          let index = 0
+          for (let entry of this.sortedMessages) {
+            index++
+            if (entry.range.compare(message.range) === -1) {
+              this.sortedMessages.splice(index - 1, 0, message)
+              this.messagesElement.insertBefore(messageElement, this.messages.get(entry).nextSibling)
+              inserted = true
+              break
+            }
+          }
+          if (!inserted) {
+            this.messagesElement.insertBefore(messageElement, this.messagesElement.firstElementChild)
+            this.sortedMessages.push(message)
+          }
+        } else {
+          this.messagesElement.appendChild(messageElement)
+        }
+      })
     }
 
     this.updateVisibility()
@@ -104,6 +129,12 @@ export default class BottomPanel {
         if (messageElement.status) {
           this.visibleMessages--
         }
+        if (this.sortMessages && message.range) {
+          const index = this.sortedMessages.indexOf(message)
+          if (index !== -1) {
+            this.sortedMessages.splice(index, 1)
+          }
+        }
       }
     }
   }
@@ -123,6 +154,7 @@ export default class BottomPanel {
   dispose() {
     this.subscriptions.dispose()
     this.messages.clear()
+    this.sortedMessages = []
     this.panel.destroy()
   }
 }

--- a/lib/ui/bottom-panel.js
+++ b/lib/ui/bottom-panel.js
@@ -91,7 +91,7 @@ export default class BottomPanel {
           let index = 0
           for (let entry of this.sortedMessages) {
             index++
-            if (entry.range.compare(message.range) === -1) {
+            if (entry.filePath === message.filePath && entry.range.compare(message.range) === -1) {
               this.sortedMessages.splice(index - 1, 0, message)
               this.messagesElement.insertBefore(messageElement, this.messages.get(entry).nextSibling)
               inserted = true

--- a/lib/validate.coffee
+++ b/lib/validate.coffee
@@ -16,6 +16,9 @@ module.exports = Validate =
       throw new Error('Linter.name must be a string') if typeof linter.name isnt 'string'
     else
       linter.name = null
+    if linter.scope
+      linter.scope = linter.scope.toLowerCase()
+    throw new Error('Linter.scope must be either `file` or `project`') if linter.scope isnt 'file' and linter.scope isnt 'project'
     return true
 
   messages: (messages, linter) ->

--- a/spec/common.coffee
+++ b/spec/common.coffee
@@ -4,7 +4,7 @@ Validators = require('../lib/validate')
 
 module.exports =
   getLinter: ->
-    return {grammarScopes: ['*'], lintOnFly: false, modifiesBuffer: false, scope: 'project', lint: -> }
+    return {grammarScopes: ['*'], lintOnFly: false, scope: 'project', lint: -> }
   getMessage: (type, filePath, range) ->
     message = {type, text: 'Some Message', filePath, range}
     Validators.messages([message], {name: 'Some Linter'})

--- a/spec/ui/bottom-panel-spec.coffee
+++ b/spec/ui/bottom-panel-spec.coffee
@@ -48,15 +48,18 @@ describe 'BottomPanel', ->
         getMessage('Error', path, [[2, 0], [2, 1]]),
         getMessage('Error', path, [[1, 0], [1, 1]]),
         getMessage('Error', path, [[5, 0], [5, 1]]),
-        getMessage('Error', path, [[3, 0], [3, 1]])
+        getMessage('Error', path, [[3, 0], [3, 1]]),
+        getMessage('Error', '/tmp/test', [[1, 0], [1, 1]]),
       ]})
       Array.prototype.forEach.call(bottomPanel.messagesElement.childNodes, (entry) ->
         entry.attachedCallback?() # No idea why but Custom Elements' attachedCallback is not triggered in test suite
       )
-      expect(bottomPanel.messagesElement.childNodes[0].textContent).toContain('line 1 col 1')
-      expect(bottomPanel.messagesElement.childNodes[1].textContent).toContain('line 2 col 1')
-      expect(bottomPanel.messagesElement.childNodes[2].textContent).toContain('line 3 col 1')
-      expect(bottomPanel.messagesElement.childNodes[3].textContent).toContain('line 4 col 1')
-      expect(bottomPanel.messagesElement.childNodes[4].textContent).toContain('line 6 col 1')
-      expect(bottomPanel.messagesElement.childNodes.length).toBe(5)
+      expect(bottomPanel.messagesElement.childNodes[0].textContent).toContain('line 2 col 1')
+      expect(bottomPanel.messagesElement.childNodes[0].textContent).toContain('/tmp/test')
+      expect(bottomPanel.messagesElement.childNodes[1].textContent).toContain('line 1 col 1')
+      expect(bottomPanel.messagesElement.childNodes[2].textContent).toContain('line 2 col 1')
+      expect(bottomPanel.messagesElement.childNodes[3].textContent).toContain('line 3 col 1')
+      expect(bottomPanel.messagesElement.childNodes[4].textContent).toContain('line 4 col 1')
+      expect(bottomPanel.messagesElement.childNodes[5].textContent).toContain('line 6 col 1')
+      expect(bottomPanel.messagesElement.childNodes.length).toBe(6)
 

--- a/spec/ui/bottom-panel-spec.coffee
+++ b/spec/ui/bottom-panel-spec.coffee
@@ -8,9 +8,10 @@ describe 'BottomPanel', ->
     waitsForPromise ->
       atom.packages.activatePackage('linter').then ->
         linter = atom.packages.getActivePackage('linter').mainModule.instance
+      .then ->
+        atom.workspace.open(__dirname + '/../fixtures/file.txt')
 
-  getMessage = (type, filePath) ->
-    return {type, text: 'Some Message', filePath}
+  {getMessage, getLinter} = require('../common')
 
   it 'is not visible when there are no errors', ->
     expect(linter.views.bottomPanel.getVisibility()).toBe(false)
@@ -37,3 +38,25 @@ describe 'BottomPanel', ->
       expect(bottomPanel.element.childNodes[0].childNodes.length).toBe(2)
       bottomPanel.removeMessages(messages)
       expect(bottomPanel.element.childNodes[0].childNodes.length).toBe(0)
+
+    it 'sorts messages', ->
+      bottomPanel.scope = 'Project'
+      atom.config.set('linter.sortMessages', true)
+      path = __dirname + '/../fixtures/file.txt'
+      bottomPanel.setMessages({removed: [], added: [
+        getMessage('Error', path, [[0, 0], [0, 1]]),
+        getMessage('Error', path, [[2, 0], [2, 1]]),
+        getMessage('Error', path, [[1, 0], [1, 1]]),
+        getMessage('Error', path, [[5, 0], [5, 1]]),
+        getMessage('Error', path, [[3, 0], [3, 1]])
+      ]})
+      Array.prototype.forEach.call(bottomPanel.messagesElement.childNodes, (entry) ->
+        entry.attachedCallback?() # No idea why but Custom Elements' attachedCallback is not triggered in test suite
+      )
+      expect(bottomPanel.messagesElement.childNodes[0].textContent).toContain('line 1 col 1')
+      expect(bottomPanel.messagesElement.childNodes[1].textContent).toContain('line 2 col 1')
+      expect(bottomPanel.messagesElement.childNodes[2].textContent).toContain('line 3 col 1')
+      expect(bottomPanel.messagesElement.childNodes[3].textContent).toContain('line 4 col 1')
+      expect(bottomPanel.messagesElement.childNodes[4].textContent).toContain('line 6 col 1')
+      expect(bottomPanel.messagesElement.childNodes.length).toBe(5)
+


### PR DESCRIPTION
We can then use the same sorted messages in commands to jump to next message in asc order.

ToDo:
  - [x] Make it keep messages of different files separate

Fixes #865 
Fixes #833

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atom-community/linter/950)
<!-- Reviewable:end -->
