### PR TITLE
fix an issue where linter.displayLinterInfo was not respected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming
 
 * Add `ignoreMatchedFiles` config
+* Fix an issue where the `linter.displayLinterInfo` preference was not respected
 
 ## 1.9.0
 

--- a/lib/linter-views.js
+++ b/lib/linter-views.js
@@ -38,7 +38,7 @@ export default class LinterViews {
       })
       this.updateCounts()
       this.bottomPanel.refresh()
-      this.bottomContainer.visibility = isEditor
+      this.bottomContainer.visibility = isEditor && atom.config.get('linter.displayLinterInfo')
     }))
     this.subscriptions.add(this.bottomContainer.onDidChangeTab(scope => {
       this.emitter.emit('did-update-scope', scope)


### PR DESCRIPTION
Fix an issue where `linter.displayLinterInfo` was not respected. The bottom status bar was reset to visible irrespective of the user's preference -