### PR TITLE
Better name on the `linter:togglePanel` command

### DIFF
--- a/lib/commands.coffee
+++ b/lib/commands.coffee
@@ -7,7 +7,7 @@ class Commands
       'linter:next-error': => @nextError()
       'linter:previous-error': => @previousError()
       'linter:toggle': => @toggleLinter()
-      'linter:togglePanel': => @togglePanel()
+      'linter:toggle-panel': => @togglePanel()
       'linter:set-bubble-transparent': => @setBubbleTransparent()
       'linter:expand-multiline-messages': => @expandMultilineMessages()
       'linter:lint': => @lint()


### PR DESCRIPTION
`linter:togglePanel` is not a good command name, it should be `linter:toggle-panel`.

It should be consistent with command name conventions.