### PR TITLE
typo when registering with indie-registry

### DIFF
--- a/lib/indie-registry.js
+++ b/lib/indie-registry.js
@@ -26,7 +26,7 @@ export default class IndieRegistry {
     indieLinter.onDidUpdateMessages(messages => {
       this.emitter.emit('did-update-messages', {linter: indieLinter, messages})
     })
-    this.emit('observe', indieLinter)
+    this.emitter.emit('observe', indieLinter)
 
     return indieLinter
   }


### PR DESCRIPTION
Thank you for making a really simple API!

I'm using it for something non-lint-related ([GitHub Pull Requests](https://atom.io/packages/pull-requests) package) and except for this typo, it worked surprisingly well!


Also, where in [atomlinter.github.io/providers.yml](https://github.com/AtomLinter/atomlinter.github.io/blob/master/_data/providers.yml) should I add a link to [GitHub Pull Requests](https://atom.io/packages/pull-requests)? `Generic Linters / Writing Assistance` or `Generic Linters / Project Organization` or some other place?

Screenshot:

![GitHub Pull Requests](https://cloud.githubusercontent.com/assets/253202/11326511/82360626-9139-11e5-8466-ed2d356cb0d8.png)