### PR TITLE
Add message registry benchmarks

### DIFF
--- a/benchmarks/common.js
+++ b/benchmarks/common.js
@@ -1,0 +1,20 @@
+'use babel'
+
+import {getMessage} from '../spec/common'
+
+export function timeNow() {
+  return process.hrtime()
+}
+
+export function timeDiff(last) {
+  const diff = process.hrtime(last)
+  return Math.round((diff[0] + (diff[1] * 1e-9)) * 1000)
+}
+
+export function getMessages(count) {
+  const messages = []
+  for (let i = 0; i < count; ++i) {
+    messages.push(getMessage('Error'))
+  }
+  return messages
+}

--- a/benchmarks/message-registry.js
+++ b/benchmarks/message-registry.js
@@ -1,0 +1,41 @@
+'use babel'
+
+import MessageRegistry from '../lib/message-registry'
+import {getLinter, getMessage} from '../spec/common'
+import {timeNow, timeDiff, getMessages} from './common'
+
+const messageRegistry = new MessageRegistry()
+messageRegistry.active = false // Disable the auto-updater
+messageRegistry.shouldRefresh = false // Disable the auto-updater
+const linter = getLinter()
+
+let time = null
+let messages = null
+
+function benchmarkRegistry(i) {
+  messages = getMessages(5000)
+  time = timeNow()
+
+  messageRegistry.set({linter, messages})
+  if (messageRegistry.updatePublic) {
+    messageRegistry.updatePublic()
+  } else if (messageRegistry.processQueue) {
+    messageRegistry.processQueue()
+  }
+  const diff = timeDiff(time)
+  console.log('iteration #', i,'took', diff, 'ms')
+  return diff
+}
+
+let promise = Promise.resolve()
+let sum = 0
+let count = 1000
+
+for (let i = 0; i < count; ++i) {
+  promise = promise.then(function() {
+    sum += benchmarkRegistry(i)
+  })
+}
+promise.then(function() {
+  console.log('average', sum / count)
+})


### PR DESCRIPTION
Just like the title says

The way I run them is that I run atom in spec runner mode in package root, then open it's dev console and paste this 
```
require('/home/steel/.atom/packages/linter/benchmarks/message-registry.js')
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atom-community/linter/1024)
<!-- Reviewable:end -->
